### PR TITLE
Remove need to subscribe to PreparingUpdateRequest

### DIFF
--- a/Salesforce.Core/Models/SObject.cs
+++ b/Salesforce.Core/Models/SObject.cs
@@ -103,11 +103,10 @@ namespace Salesforce
 		internal IDictionary<string,string> OnPreparingUpdateRequest()
 		{
 			var evt = PreparingUpdateRequest;
-			IDictionary<string,string> opts = null;
+			IDictionary<string,string> opts = Options.ToDictionary(k => k.Key, v => (String)v.Value);
 			if (evt != null)
 			{
-				opts = Options.ToDictionary (k => k.Key, v => (String)v.Value);
-				evt (this, new UpdateRequestEventArgs (opts));
+				evt (this, new UpdateRequestEventArgs(opts));
 			}
 			return opts;
 		}

--- a/Tests.Android/Resources/Resource.designer.cs
+++ b/Tests.Android/Resources/Resource.designer.cs
@@ -33,6 +33,7 @@ namespace Tests.Android
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultFullName = global::Tests.Android.Resource.Id.ResultFullName;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultMessage = global::Tests.Android.Resource.Id.ResultMessage;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultResultState = global::Tests.Android.Resource.Id.ResultResultState;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultRunSingleMethodTest = global::Tests.Android.Resource.Id.ResultRunSingleMethodTest;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultStackTrace = global::Tests.Android.Resource.Id.ResultStackTrace;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsFailed = global::Tests.Android.Resource.Id.ResultsFailed;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsId = global::Tests.Android.Resource.Id.ResultsId;
@@ -91,20 +92,23 @@ namespace Tests.Android
 			// aapt resource value: 0x7f050000
 			public const int OptionRemoteServer = 2131034112;
 			
-			// aapt resource value: 0x7f05000f
-			public const int OptionsButton = 2131034127;
-			
-			// aapt resource value: 0x7f05000a
-			public const int ResultFullName = 2131034122;
-			
-			// aapt resource value: 0x7f05000c
-			public const int ResultMessage = 2131034124;
+			// aapt resource value: 0x7f050010
+			public const int OptionsButton = 2131034128;
 			
 			// aapt resource value: 0x7f05000b
-			public const int ResultResultState = 2131034123;
+			public const int ResultFullName = 2131034123;
 			
 			// aapt resource value: 0x7f05000d
-			public const int ResultStackTrace = 2131034125;
+			public const int ResultMessage = 2131034125;
+			
+			// aapt resource value: 0x7f05000c
+			public const int ResultResultState = 2131034124;
+			
+			// aapt resource value: 0x7f05000a
+			public const int ResultRunSingleMethodTest = 2131034122;
+			
+			// aapt resource value: 0x7f05000e
+			public const int ResultStackTrace = 2131034126;
 			
 			// aapt resource value: 0x7f050006
 			public const int ResultsFailed = 2131034118;
@@ -127,11 +131,11 @@ namespace Tests.Android
 			// aapt resource value: 0x7f050004
 			public const int ResultsResult = 2131034116;
 			
-			// aapt resource value: 0x7f05000e
-			public const int RunTestsButton = 2131034126;
+			// aapt resource value: 0x7f05000f
+			public const int RunTestsButton = 2131034127;
 			
-			// aapt resource value: 0x7f050010
-			public const int TestSuiteListView = 2131034128;
+			// aapt resource value: 0x7f050011
+			public const int TestSuiteListView = 2131034129;
 			
 			static Id()
 			{


### PR DESCRIPTION
Update operations would fail if the user did not subscribe to the
SObject.PreparingUpdateRequest event … all they needed for success was
a subscribed handler, even if that handler did zero work. This change
removes the need to subscribe to the event. Now clients only need
subscribe if they have work to do in their handler.
