### PR TITLE
Bug fixes: Auth Complete event and Refresh Token

### DIFF
--- a/Tests.Android/Resources/Resource.designer.cs
+++ b/Tests.Android/Resources/Resource.designer.cs
@@ -33,6 +33,7 @@ namespace Tests.Android
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultFullName = global::Tests.Android.Resource.Id.ResultFullName;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultMessage = global::Tests.Android.Resource.Id.ResultMessage;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultResultState = global::Tests.Android.Resource.Id.ResultResultState;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultRunSingleMethodTest = global::Tests.Android.Resource.Id.ResultRunSingleMethodTest;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultStackTrace = global::Tests.Android.Resource.Id.ResultStackTrace;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsFailed = global::Tests.Android.Resource.Id.ResultsFailed;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsId = global::Tests.Android.Resource.Id.ResultsId;
@@ -91,20 +92,23 @@ namespace Tests.Android
 			// aapt resource value: 0x7f050000
 			public const int OptionRemoteServer = 2131034112;
 			
-			// aapt resource value: 0x7f05000f
-			public const int OptionsButton = 2131034127;
-			
-			// aapt resource value: 0x7f05000a
-			public const int ResultFullName = 2131034122;
-			
-			// aapt resource value: 0x7f05000c
-			public const int ResultMessage = 2131034124;
+			// aapt resource value: 0x7f050010
+			public const int OptionsButton = 2131034128;
 			
 			// aapt resource value: 0x7f05000b
-			public const int ResultResultState = 2131034123;
+			public const int ResultFullName = 2131034123;
 			
 			// aapt resource value: 0x7f05000d
-			public const int ResultStackTrace = 2131034125;
+			public const int ResultMessage = 2131034125;
+			
+			// aapt resource value: 0x7f05000c
+			public const int ResultResultState = 2131034124;
+			
+			// aapt resource value: 0x7f05000a
+			public const int ResultRunSingleMethodTest = 2131034122;
+			
+			// aapt resource value: 0x7f05000e
+			public const int ResultStackTrace = 2131034126;
 			
 			// aapt resource value: 0x7f050006
 			public const int ResultsFailed = 2131034118;
@@ -127,11 +131,11 @@ namespace Tests.Android
 			// aapt resource value: 0x7f050004
 			public const int ResultsResult = 2131034116;
 			
-			// aapt resource value: 0x7f05000e
-			public const int RunTestsButton = 2131034126;
+			// aapt resource value: 0x7f05000f
+			public const int RunTestsButton = 2131034127;
 			
-			// aapt resource value: 0x7f050010
-			public const int TestSuiteListView = 2131034128;
+			// aapt resource value: 0x7f050011
+			public const int TestSuiteListView = 2131034129;
 			
 			static Id()
 			{


### PR DESCRIPTION
This commit has two bug fixes.

1. AuthenticationComplete event
a) The previous implementation only raised the event on successful
authentication. This did not match the recommended style for client
code included in the samples: the samples recommend testing the
IsAuthenticated flag in the event args to determine success; however,
the event was only being raised on success so this test was
unnecessary. This commit changes the behavior so the event is raised
every time the underlying OAuth2Authenticator reports that
authentication has completed. The behavior will now match the
recommended style for the client code in the provided samples. The
behavior should now match user expectations.

b) ForceUserReauthorization(false) is now called upon successful
authentication. Previously, it was called only if the authentication
was successful AND the client has subscribed to the event. This was
unintuitive behavior: the SaleforceClient should not change when/how it
saves user accounts to disk based on whether the client subscribed a
completed handler.

c) The ‘sender’ argument passed to clients via this event was changed
from the OAuth2Authenticator to the SalesforceClient. Passing the
OAuth2Authenticator violated the .NET guidelines for events and it
exposed a protected field to the client.

2. Refresh token bug fix
The private method RefreshSessionToken was failing if the user had
logged in during the current session. This is because the
SalesforceClient constructor sets AccessTokenUrl to null when a login
is needed in order to force the OAuth2Authenticator to use the
User-Agent Flow rather than the Web-Server Flow. Since AccessTokenUrl
is null in the Authenticator, the WebRequest.Create() call in the
Authenticator throws an exception when this refresh code executes.
Refresh did work if the user logged in, saved the user to disk, closed
the app, and restarted it since then the SalesforceClient constructor
did not set AccessTokenUrl to null in the Authenticator. This bug fix
allows refresh to work in both cases.